### PR TITLE
UMA authorization

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ The following configuration is supported:
 |-lifetime|int|Session length in seconds (default 43200)|
 |-url-path|string|Callback URL (default "_oauth")|
 |-prompt|string|Space separated list of [OpenID prompt options](https://developers.google.com/identity/protocols/OpenIDConnect#prompt)|
+|-uma_authorization|bool|whether [UMA](https://docs.kantarainitiative.org/uma/wg/oauth-uma-grant-2.0-05.html)-based authorization will be performed|
 |-log-level|string|Log level: trace, debug, info, warn, error, fatal, panic (default "warn")|
 |-log-format|string|Log format: text, json, pretty (default "text")|
 

--- a/README.md
+++ b/README.md
@@ -80,12 +80,13 @@ The following configuration is supported:
 |-cookie-name|string|Cookie Name (default "_forward_auth")|
 |-cookie-secure|bool|Use secure cookies (default true)|
 |-csrf-cookie-name|string|CSRF Cookie Name (default "_forward_auth_csrf")|
+|-insecure-certificates|bool|Allow insecure certificates (default false)|
 |-domain|string|Comma separated list of email domains to allow|
 |-whitelist|string|Comma separated list of email addresses to allow|
 |-lifetime|int|Session length in seconds (default 43200)|
 |-url-path|string|Callback URL (default "_oauth")|
 |-prompt|string|Space separated list of [OpenID prompt options](https://developers.google.com/identity/protocols/OpenIDConnect#prompt)|
-|-uma_authorization|bool|whether [UMA](https://docs.kantarainitiative.org/uma/wg/oauth-uma-grant-2.0-05.html)-based authorization will be performed|
+|-uma_authorization|bool|whether [UMA](https://docs.kantarainitiative.org/uma/wg/oauth-uma-grant-2.0-05.html)-based authorization will be performed (default false)|
 |-log-level|string|Log level: trace, debug, info, warn, error, fatal, panic (default "warn")|
 |-log-format|string|Log format: text, json, pretty (default "text")|
 

--- a/forwardauth.go
+++ b/forwardauth.go
@@ -37,11 +37,13 @@ type ForwardAuth struct {
 	CSRFCookieName string
 	CookieSecure   bool
 
+	InsecureCertificates bool
+
 	Domain    []string
 	Whitelist []string
 
 	Prompt           string
-	UmaAuthorization bool
+	UMAAuthorization bool
 }
 
 // Request Validation
@@ -146,10 +148,10 @@ func (f *ForwardAuth) ExchangeCode(r *http.Request, code string) (string, error)
 	form.Set("redirect_uri", f.redirectUri(r))
 	form.Set("code", code)
 
-	// allow self-signed certs
+	// allow insecure certificates when enabled
 	client := http.Client{
 		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: f.InsecureCertificates},
 		},
 	}
 
@@ -168,10 +170,10 @@ func (f *ForwardAuth) ExchangeCode(r *http.Request, code string) (string, error)
 // VerifyAccess checks whether access is allowed to all resources of the client using the UMA protocol.
 // https://www.keycloak.org/docs/4.8/authorization_services/index.html#_service_obtaining_permissions
 func (f *ForwardAuth) VerifyAccess(token string) (bool, error) {
-	// allow self-signed certs
+	// allow insecure certificates when enabled
 	client := http.Client{
 		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: f.InsecureCertificates},
 		},
 	}
 
@@ -208,7 +210,7 @@ func (f *ForwardAuth) GetUser(token string) (User, error) {
 
 	client := &http.Client{
 		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: f.InsecureCertificates},
 		},
 	}
 	req, err := http.NewRequest("GET", fw.UserURL.String(), nil)

--- a/forwardauth.go
+++ b/forwardauth.go
@@ -188,6 +188,9 @@ func (f *ForwardAuth) VerifyAccess(token string) (bool, error) {
 
 	// status code is 403 when not allowed by authorization server
 	isAllowedAccess := err == nil && res.StatusCode == 200
+
+	defer res.Body.Close()
+
 	return isAllowedAccess, err
 }
 


### PR DESCRIPTION
UMA (User Managed Access) is an extension of the OAuth 2 protocol, which allows a client to request access to a protected resource, of which the permissions are strictly defined in a resource server.

The implementation in this forward-auth proxy has the client request access to all resources on the resource server (configured in Keycloak, where the Keycloak client acts and is configured like a resource server). When the authorization server denies the request for access, it returns a 403, otherwise a 200 response.
```
curl -X POST \
  http://${host}:${port}/auth/realms/${realm}/protocol/openid-connect/token \
  -H "Authorization: Bearer ${access_token}" \
  --data "grant_type=urn:ietf:params:oauth:grant-type:uma-ticket" \
  --data "audience={resource_server_client_id}"
```
More info: 
- [Keycloak UMA Support](https://www.keycloak.org/docs/4.8/authorization_services/index.html#_service_obtaining_permissions)
- [UMA 2.0 Specification](https://docs.kantarainitiative.org/uma/wg/oauth-uma-grant-2.0-05.html)
- [UMA 2 in Action](https://wso2.com/articles/2019/3/user-managed-access-in-action-part-one)