### PR TITLE
adding security-related response headers and secure cookies

### DIFF
--- a/forwardauth.go
+++ b/forwardauth.go
@@ -42,7 +42,8 @@ type ForwardAuth struct {
 	CookieName     string
 	CookieDomains  []CookieDomain
 	CSRFCookieName string
-	CookieSecure   bool
+
+	Secure bool
 
 	InsecureCertificates bool
 
@@ -304,7 +305,7 @@ func (f *ForwardAuth) ClearCSRFCookie(r *http.Request) *http.Cookie {
 		Path:     "/",
 		Domain:   f.csrfCookieDomain(r),
 		HttpOnly: true,
-		Secure:   f.CookieSecure,
+		Secure:   f.Secure,
 		Expires:  time.Now().Local().Add(time.Hour * -1),
 	}
 }
@@ -317,7 +318,7 @@ func (f *ForwardAuth) ClearCookie(r *http.Request, name string) *http.Cookie {
 		Path:     "/",
 		Domain:   f.cookieDomain(r),
 		HttpOnly: true,
-		Secure:   f.CookieSecure,
+		Secure:   f.Secure,
 		Expires:  time.Now().Local().Add(time.Hour * -1),
 	}
 }
@@ -336,7 +337,7 @@ func (f *ForwardAuth) MakeCSRFCookie(r *http.Request, nonce string) *http.Cookie
 		Path:     "/",
 		Domain:   f.csrfCookieDomain(r),
 		HttpOnly: true,
-		Secure:   f.CookieSecure,
+		Secure:   f.Secure,
 		Expires:  f.cookieExpiry(),
 	}
 }
@@ -351,7 +352,7 @@ func (f *ForwardAuth) MakeCookieWithExpiry(r *http.Request, name, content string
 		Path:     "/",
 		Domain:   f.cookieDomain(r),
 		HttpOnly: true,
-		Secure:   f.CookieSecure,
+		Secure:   f.Secure,
 		Expires:  expires,
 	}
 }

--- a/main.go
+++ b/main.go
@@ -30,6 +30,14 @@ func handler(w http.ResponseWriter, r *http.Request) {
 		"Headers": r.Header,
 	}).Debug("Handling request")
 
+	// Set security-related headers on the potential response
+	if fw.Secure {
+		w.Header().Set("X-Content-Type-Options", "nosniff")
+		w.Header().Set("X-XSS-Protection", "1; mode=block")
+		w.Header().Set("X-Frame-Options", "SAMEORIGIN")
+		w.Header().Set("Strict-Transport-Security", "max-age=15552000; includeSubDomains")
+	}
+
 	// Parse uri
 	uri, err := url.Parse(r.Header.Get("X-Forwarded-Uri"))
 	if err != nil {
@@ -286,7 +294,7 @@ func main() {
 	cSRFCookieName := flag.String("csrf-cookie-name", "_forward_auth_csrf", "CSRF Cookie Name")
 	cookieDomainList := flag.String("cookie-domains", "", "Comma separated list of cookie domains") //todo
 	cookieSecret := flag.String("cookie-secret", "", "Deprecated")
-	cookieSecure := flag.Bool("cookie-secure", true, "Use secure cookies")
+	secure := flag.Bool("secure", true, "Use secure configuration")
 	insecureCertificates := flag.Bool("insecure-certificates", false, "Allow insecure certificates")
 	domainList := flag.String("domain", "", "Comma separated list of email domains to allow")
 	emailWhitelist := flag.String("whitelist", "", "Comma separated list of emails to allow")
@@ -375,7 +383,8 @@ func main() {
 		CookieName:     *cookieName,
 		CSRFCookieName: *cSRFCookieName,
 		CookieDomains:  cookieDomains,
-		CookieSecure:   *cookieSecure,
+
+		Secure: *secure,
 
 		InsecureCertificates: *insecureCertificates,
 


### PR DESCRIPTION
replacing the `CookieSecure` option with a more general `Secure` option, which when enabled will turn on various security enhancements:
- secure cookies
- HSTS headers on responses
- `X-Frame-Options: SAMEORIGIN` response header as a clickjacking defense
- `Content-Security-Policy: nosniff` response header 
- `X-XSS-Protection` response header against cross-site scripting attacks