### PR TITLE
session management refactor & token refresh optimization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,4 +15,4 @@ format:
 
 .PHONY: test
 test:
-	go test -v .
+	go test -v ./...

--- a/session/inventory.go
+++ b/session/inventory.go
@@ -1,0 +1,231 @@
+package session
+
+import (
+	"fmt"
+	"github.com/Klarrio/traefik-forward-auth/ttlmap"
+	oidc "github.com/Klarrio/traefik-forward-auth/wellknownopenidconfiguration"
+	"github.com/sirupsen/logrus"
+	"sync"
+	"time"
+)
+
+type Inventory struct {
+	stateMap                     	ttlmap.TTLMap
+	oidcEndpoint 					*oidc.WellKnownOpenIDConfiguration
+	tokenValidatorEnabled        	bool
+	logger 							logrus.FieldLogger
+}
+
+type Metadata struct {
+	SessionKey string
+	ExpiresAt  time.Time
+}
+
+func NewInventory(oidcEndpoint *oidc.WellKnownOpenIDConfiguration, tokenValidatorEnabled bool, logger logrus.FieldLogger) *Inventory {
+	stateMap, err := ttlmap.New()
+	if err != nil {
+		panic(err)
+	}
+
+	return &Inventory{ stateMap:  stateMap, oidcEndpoint: oidcEndpoint, tokenValidatorEnabled: tokenValidatorEnabled, logger: logger}
+}
+
+func (i *Inventory) StoreSession(sessionKey string, token *oidc.Token, expiry time.Time) {
+	i.stateMap.AddWithTTL(sessionKey, token, expiry.Sub(time.Now()))
+}
+
+func (i *Inventory) RemoveSession(sessionKey string) {
+	i.stateMap.Remove(sessionKey) // cleanup
+}
+
+func (i *Inventory) SessionMetadata(sessionKey string) (metadata *Metadata, sessionExists bool) {
+	sessionState, sessionExists := i.stateMap.Get(sessionKey)
+	if sessionExists {
+		sessionMetadata := &Metadata {
+			SessionKey: sessionKey,
+			ExpiresAt:  sessionState.ExpiresAt(),
+		}
+		return sessionMetadata, sessionExists
+	}
+
+	return nil, sessionExists
+}
+
+/**
+ * will retrieve the token for the given session if available, or a pending token channel in case the token is being
+ * refreshed. Only one of both is being returned. If both are nil, then it means no token exists for the session.
+ */
+func (i *Inventory) sessionToken(sessionKey string) (availableToken *oidc.Token, pendingToken chan *TokenResult) {
+	sessionState, sessionExists := i.stateMap.Get(sessionKey)
+	if sessionExists {
+		switch val := sessionState.Value().(type) {
+		case *oidc.Token:
+			return val, nil
+		case *TokenPromise:
+			return nil, val.ToChannel()
+		default:
+			return nil, nil
+		}
+	} else {
+		return nil, nil
+	}
+}
+
+/**
+ * Will try to ensure a valid access token. If the token has expired or is about to expire, it will be refreshed. If the
+ * token doesn't need to be refreshed, it will be validated (when validation is enabled).
+ * When no valid access token can be returned, then the return values will be nil or an empty string.
+ */
+func (i *Inventory) EnsureValidAccessToken(sessionKey string, tokenMinValidity time.Duration) (accessToken *oidc.BearerToken, rawAccessToken string) {
+	sessionMetadata, sessionExists := i.SessionMetadata(sessionKey)
+	if !sessionExists {
+		i.logger.Error("unable to ensure valid token when no session exists")
+		return nil, ""
+	}
+
+	tokenRefreshed := false
+	var storedToken *oidc.Token
+	var bearerToken *oidc.BearerToken
+	var err error
+
+	// lock this block of logic, such that only one thread can access it at the same time.
+	// This block will determine whether the token needs to be refreshed, and if so, the current thread will take
+	// responsibility of doing it. Meanwhile, it will assign a pendingToken to the session, so that all other
+	// threads of this session will receive this pending token and will have to wait for the refreshed token.
+	// This to avoid that multiple threads/requests try to refresh the same token at the same time, which may result
+	// in token refresh failures and unneeded pressure on the oidc server.
+	// ---- BEGIN OF LOCK ----
+	var mutex = &sync.Mutex{}
+	mutex.Lock()
+	availableToken, pendingToken := i.sessionToken(sessionKey)
+
+	if availableToken == nil && pendingToken == nil {
+		i.logger.Error("no valid token found for session %s", sessionKey)
+		return nil, ""
+	}
+
+	if availableToken != nil {
+		storedToken = availableToken
+		bearerToken, err = oidc.BearerTokenFromWire(storedToken.AccessToken)
+		if err != nil {
+			i.logger.Error("Error parsing stored token, reason ", err)
+			return nil, ""
+		}
+
+		isAboutToExpire := (bearerToken.Exp - time.Now().Unix()) < (tokenMinValidity.Milliseconds() / 1000) // expires in less then tokenMinValidity
+		if isAboutToExpire {
+			pendingToken = i.pauseSessionAndRefreshToken(sessionMetadata, storedToken).ToChannel()
+		}
+	}
+	mutex.Unlock()
+	// ---- END OF LOCK ----
+
+	if pendingToken != nil {
+		i.logger.WithField("sessionKey", sessionMetadata.SessionKey).Debug("waiting for pending token")
+		// wait for the token to be refreshed, which we'll receive through the channel
+		tokenResult := <-pendingToken
+		if tokenResult.err != nil {
+			i.logger.Error("failed to acquire refreshed token", tokenResult.err)
+			return nil, ""
+		}
+
+		storedToken = tokenResult.token
+		bearerToken, err = oidc.BearerTokenFromWire(storedToken.AccessToken)
+		tokenRefreshed = true
+	}
+
+	if storedToken == nil {
+		i.logger.WithField("token refreshed", tokenRefreshed).Error("unexpected token unavailability")
+		return nil, ""
+	}
+
+	// either this thread:
+	//   - needed to refresh the token (no token validation required anymore)
+	//   - immediately received the available token (token validation might be required)
+	//	 - had to wait for the token until it was refreshed (no token validation required anymore)
+	if i.tokenValidatorEnabled && !tokenRefreshed {
+		if i.validateToken(storedToken) {
+			i.logger.WithFields(logrus.Fields{
+				"token-validation": true,
+				"token refreshed": tokenRefreshed,
+			}).Debug("access token valid")
+			return bearerToken, storedToken.AccessToken
+		} else {
+			i.logger.WithFields(logrus.Fields{
+				"token-validation": true,
+				"token refreshed": tokenRefreshed,
+			}).Debug("access token not valid or validity could not be determined")
+			return nil, ""
+		}
+	} else {
+		// Valid request
+		i.logger.WithFields(logrus.Fields{
+			"token-validation": false,
+			"token refreshed": tokenRefreshed,
+		}).Debug("access token valid")
+		return bearerToken, storedToken.AccessToken
+	}
+}
+
+/**
+ * Updates the session state with a promise for a token, while executing the token refresh.
+ */
+func (i *Inventory) pauseSessionAndRefreshToken(sessionMetadata *Metadata, token *oidc.Token) *TokenPromise {
+	tokenPromise := NewTokenPromise(func () (*oidc.Token, error) {
+		storedToken, tokenRefreshed := i.refreshToken(sessionMetadata, token)
+		if !tokenRefreshed {
+			return nil, fmt.Errorf("failed to refresh token for session %s", sessionMetadata.SessionKey)
+		} else {
+			return storedToken, nil
+		}
+	})
+	exp := sessionMetadata.ExpiresAt.Sub(time.Now())
+	i.stateMap.AddWithTTL(sessionMetadata.SessionKey, tokenPromise, exp)
+
+	return tokenPromise
+}
+
+func (i *Inventory) refreshToken(sessionMetadata *Metadata, token *oidc.Token) (newToken *oidc.Token, refreshed bool) {
+	refreshedToken, refreshError := i.oidcEndpoint.TokenRefresh(token.RefreshToken)
+	if refreshError != nil {
+		i.logger.WithFields(logrus.Fields{
+			"refresh-token-error": refreshError,
+		}).Error("error while refreshing token")
+		return nil, false
+	}
+
+	exp := sessionMetadata.ExpiresAt.Sub(time.Now())
+	newTokenEntry := &oidc.Token{
+		AccessToken:  refreshedToken.AccessToken,
+		TokenType:    refreshedToken.TokenType,
+		RefreshToken: refreshedToken.RefreshToken,
+		ExpiresIn:    refreshedToken.ExpiresIn,
+	}
+	i.stateMap.AddWithTTL(sessionMetadata.SessionKey, newTokenEntry, exp)
+
+	i.logger.Infof("Updated session map with refreshed token for session %s", sessionMetadata.SessionKey)
+
+	return newTokenEntry, true
+}
+
+func (i *Inventory) validateToken(token *oidc.Token) (valid bool) {
+	validationResult, err := i.oidcEndpoint.ValidateToken(token.AccessToken)
+	if err != nil {
+		i.logger.WithFields(logrus.Fields{
+			"error": err,
+		}).Error("Failed to validate token")
+		return false
+	}
+
+	if validationResult.Active {
+		i.logger.WithFields(logrus.Fields{
+			"result": validationResult,
+		}).Debug("Allowing valid request")
+	} else {
+		i.logger.WithFields(logrus.Fields{
+			"result": validationResult,
+		}).Info("Token invalid")
+	}
+
+	return validationResult.Active
+}

--- a/session/tokenpromise.go
+++ b/session/tokenpromise.go
@@ -1,0 +1,69 @@
+package session
+
+import (
+	oidc "github.com/Klarrio/traefik-forward-auth/wellknownopenidconfiguration"
+	"sync"
+)
+
+/**
+ * A Promise structure, that promises to provide a token eventually, or an error in case it can't provide it.
+ * Can be constructed using the NewTokenPromise(tokenGenerationFunction) function, and you can wait for the token
+ * result using the promise.Then(successHandler, errorHandler) function, or by converting the promise to a Go channel with
+ * the promise.ToChannel() function.
+ */
+type TokenPromise struct {
+	wg sync.WaitGroup
+	token *oidc.Token
+	err error
+}
+
+type TokenResult struct {
+	token *oidc.Token
+	err error
+}
+
+func NewTokenPromise(tokenGenerationFunction func() (*oidc.Token, error)) *TokenPromise {
+	p := &TokenPromise{}
+	p.wg.Add(1)
+	go func() {
+		p.token, p.err = tokenGenerationFunction()
+		p.wg.Done()
+	}()
+	return p
+}
+
+/**
+ * To handle the result of the promise, which is either the token or an error.
+ */
+func (p *TokenPromise) Then(successHandler func(token *oidc.Token), errorHandler func(error)) {
+	go func() {
+		p.wg.Wait()
+		if p.err != nil {
+			errorHandler(p.err)
+			return
+		}
+		successHandler(p.token)
+	}()
+}
+
+/**
+ * Convert the promise to a Go channel, on which you can then wait for the result.
+ * Each invocation of this method returns a new channel, which will deliver the result even if
+ * the promise has already completed.
+ */
+func (p *TokenPromise) ToChannel() chan *TokenResult {
+	tokenChannel := make(chan *TokenResult)
+	p.Then(
+		func (token *oidc.Token) {
+			tokenChannel <- &TokenResult{
+				token: token,
+			}
+		},
+		func (err error) {
+			tokenChannel <- &TokenResult{
+				err: err,
+			}
+		})
+
+	return tokenChannel
+}

--- a/session/tokenpromise_test.go
+++ b/session/tokenpromise_test.go
@@ -1,0 +1,29 @@
+package session
+
+import (
+	oidc "github.com/Klarrio/traefik-forward-auth/wellknownopenidconfiguration"
+	"testing"
+)
+
+func TestTokenPromise(t *testing.T) {
+	expectedToken := &oidc.Token{}
+	p := NewTokenPromise(func ()(*oidc.Token, error) {
+		return expectedToken, nil
+	})
+
+	// should properly return the expected result
+	tokenResult := <- p.ToChannel()
+
+	if tokenResult.err != nil {
+		t.Error("token result shouldn't have an error")
+	}
+	if tokenResult.token != expectedToken {
+		t.Error("token result didn't contain expected token")
+	}
+
+	// when already completed, should still return the result for new channels on the same promise
+	tokenResult = <- p.ToChannel()
+	if tokenResult.token != expectedToken {
+		t.Error("didn't return the expected token a second time for a different channel")
+	}
+}

--- a/util/log.go
+++ b/util/log.go
@@ -1,4 +1,4 @@
-package main
+package util
 
 import (
 	"os"

--- a/wellknownopenidconfiguration/implementation.go
+++ b/wellknownopenidconfiguration/implementation.go
@@ -2,26 +2,29 @@ package wellknownopenidconfiguration
 
 import (
 	"bytes"
+	"crypto/tls"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/sirupsen/logrus"
 )
 
-// TokenValidationEndpointCredentials represents token introspection credentials.
-type TokenValidationEndpointCredentials struct {
-	Username string
-	Password string
+// OIDCClientCredentials represents the OIDC client credentials that are required to communicate with the oidc server.
+type OIDCClientCredentials struct {
+	ClientID     string
+	ClientSecret string
 }
 
 // MaybeAddBasicAuth adds the Authentication header to the request, if username and password are not empty strings.
-func (t *TokenValidationEndpointCredentials) MaybeAddBasicAuth(request *http.Request) bool {
-	if t.Username != "" && t.Password != "" {
-		auth := t.Username + ":" + t.Password
+func (t *OIDCClientCredentials) MaybeAddBasicAuth(request *http.Request) bool {
+	if t.ClientID != "" && t.ClientSecret != "" {
+		auth := t.ClientID + ":" + t.ClientSecret
 		request.Header.Add("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(auth)))
 		return true
 	}
@@ -32,7 +35,13 @@ func (t *TokenValidationEndpointCredentials) MaybeAddBasicAuth(request *http.Req
 // fetched from the realm .well-known/openid-configuration HTTP endpoint.
 type WellKnownOpenIDConfiguration struct {
 	logger                     logrus.FieldLogger
-	credentials                *TokenValidationEndpointCredentials
+	credentials                *OIDCClientCredentials
+	loginURL				   *url.URL
+	tokenURL                   *url.URL
+	userURL                    *url.URL
+	scope                      string
+	prompt                     string
+	insecureCertificates 	   bool
 	Issuer                     string `json:"issuer"`
 	AuthorizationEndpoint      string `json:"authorization_endpoint"`
 	TokenEndpoint              string `json:"token_endpoint"`
@@ -42,11 +51,36 @@ type WellKnownOpenIDConfiguration struct {
 	JWKSURI                    string `json:"jwks_uri"`
 }
 
-func NewWellKnownOpenIDConfiguration(logger logrus.FieldLogger, credentials *TokenValidationEndpointCredentials) *WellKnownOpenIDConfiguration {
+func NewWellKnownOpenIDConfiguration(logger logrus.FieldLogger, credentials *OIDCClientCredentials, scope string, prompt string) *WellKnownOpenIDConfiguration {
 	return &WellKnownOpenIDConfiguration{
 		logger:      logger,
 		credentials: credentials,
+		scope: scope,
+		prompt: prompt,
 	}
+}
+
+/**
+ * Resolves its properties based on the public OIDC-based properties
+ */
+func (w *WellKnownOpenIDConfiguration) Resolve() {
+	loginURL, err := url.Parse(w.AuthorizationEndpoint)
+	if err != nil {
+		log.Fatal("unable to parse login url: ", err)
+	}
+
+	tokenURL, err := url.Parse(w.TokenEndpoint)
+	if err != nil {
+		log.Fatal("unable to parse token url: ", err)
+	}
+	userURL, err := url.Parse(w.UserInfoEndpoint)
+	if err != nil {
+		log.Fatal("unable to parse user url: ", err)
+	}
+
+	w.loginURL = loginURL
+	w.tokenURL = tokenURL
+	w.userURL = userURL
 }
 
 // TokenValidationResult represents the token validation result.
@@ -103,7 +137,7 @@ func (w *WellKnownOpenIDConfiguration) ValidateToken(token string) (*TokenValida
 
 	authHeaderAdded := w.credentials.MaybeAddBasicAuth(request)
 
-	w.logger.Warn("token validation", "with-auth", authHeaderAdded, "request-body-length", len(requestBody), "uri", w.TokenIntrospectionEndpoint)
+	w.logger.Debug("token validation", " with-auth:[", authHeaderAdded, "] request-body-length:[", len(requestBody), "] uri:[", w.TokenIntrospectionEndpoint, "]")
 
 	httpClient := &http.Client{}
 	response, responseEError := httpClient.Do(request)
@@ -121,10 +155,30 @@ func (w *WellKnownOpenIDConfiguration) ValidateToken(token string) (*TokenValida
 	return result, result.ToError()
 }
 
-// LogOut logs out given token.
-func (w *WellKnownOpenIDConfiguration) LogOut(clientID, token string) error {
+// GetLoginURL gets the login URL for the service.
+func (w *WellKnownOpenIDConfiguration) GetLoginURL(nonce string, returnUrl string, redirectUrl string) string {
+	state := fmt.Sprintf("%s:%s", nonce, returnUrl)
 
-	uriString := fmt.Sprintf("%s?client_id=%s&id_token_hint=%s", w.EndSessionEndpoint, clientID, token)
+	q := url.Values{}
+	q.Set("client_id", w.credentials.ClientID)
+	q.Set("response_type", "code")
+	q.Set("scope", w.scope)
+	if w.prompt != "" {
+		q.Set("prompt", w.prompt)
+	}
+	q.Set("redirect_uri", redirectUrl)
+	q.Set("state", state)
+
+	var u = *w.loginURL
+	u.RawQuery = q.Encode()
+
+	return u.String()
+}
+
+// LogOut logs out given token.
+func (w *WellKnownOpenIDConfiguration) LogOut(token string) error {
+
+	uriString := fmt.Sprintf("%s?client_id=%s&id_token_hint=%s", w.EndSessionEndpoint, w.credentials.ClientID, token)
 
 	request, requestError := http.NewRequest("GET", uriString, nil)
 	if requestError != nil {
@@ -150,13 +204,13 @@ func (w *WellKnownOpenIDConfiguration) LogOut(clientID, token string) error {
 }
 
 // TokenRefresh handles token refresh.
-func (w *WellKnownOpenIDConfiguration) TokenRefresh(clientID, clientSecret, refreshToken, scope string) (*TokenRefreshResult, error) {
+func (w *WellKnownOpenIDConfiguration) TokenRefresh(refreshToken string) (*TokenRefreshResult, error) {
 	form := url.Values{}
-	form.Add("client_id", clientID)
-	form.Add("client_secret", clientSecret)
+	form.Add("client_id", w.credentials.ClientID)
+	form.Add("client_secret", w.credentials.ClientSecret)
 	form.Add("grant_type", "refresh_token")
 	form.Add("refresh_token", refreshToken)
-	form.Add("scope", scope)
+	form.Add("scope", w.scope)
 	requestBody := form.Encode()
 
 	request, requestError := http.NewRequest("POST", w.TokenEndpoint, bytes.NewBuffer([]byte(requestBody)))
@@ -169,7 +223,7 @@ func (w *WellKnownOpenIDConfiguration) TokenRefresh(clientID, clientSecret, refr
 
 	authHeaderAdded := w.credentials.MaybeAddBasicAuth(request)
 
-	w.logger.Warn("token refresh", "with-auth", authHeaderAdded, "request-body-length", len(requestBody), "uri", w.TokenEndpoint)
+	w.logger.Debug("[token refresh] with-auth:[", authHeaderAdded, "] request-body-length:[", len(requestBody), "] uri:[", w.TokenEndpoint, "]")
 
 	httpClient := &http.Client{}
 	response, responseEError := httpClient.Do(request)
@@ -187,8 +241,103 @@ func (w *WellKnownOpenIDConfiguration) TokenRefresh(clientID, clientSecret, refr
 	return result, result.ToError()
 }
 
+// ExchangeCode exchanges the authorization code for the token.
+func (w *WellKnownOpenIDConfiguration) ExchangeCode(r *http.Request, code string, redirectURI string) (*Token, error) {
+	form := url.Values{}
+	form.Set("client_id", w.credentials.ClientID)
+	form.Set("client_secret", w.credentials.ClientSecret)
+	form.Set("grant_type", "authorization_code")
+	form.Set("redirect_uri", redirectURI)
+	form.Set("code", code)
+
+	// allow insecure certificates when enabled
+	client := http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: w.insecureCertificates},
+		},
+	}
+
+	token := &Token{}
+
+	res, err := client.PostForm(w.tokenURL.String(), form)
+	if err != nil {
+		return token, err
+	}
+
+	defer res.Body.Close()
+	err = json.NewDecoder(res.Body).Decode(token)
+
+	return token, err
+}
+
+// VerifyAccess checks whether access is allowed to all resources of the client using the UMA protocol.
+// https://www.keycloak.org/docs/4.8/authorization_services/index.html#_service_obtaining_permissions
+func (w *WellKnownOpenIDConfiguration) VerifyAccess(token string) (bool, error) {
+	// allow insecure certificates when enabled
+	client := http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: w.insecureCertificates},
+		},
+	}
+
+	data := url.Values{}
+	data.Set("grant_type", "urn:ietf:params:oauth:grant-type:uma-ticket")
+	data.Set("audience", w.credentials.ClientID)
+	encoded := data.Encode()
+
+	req, err := http.NewRequest(http.MethodPost, w.tokenURL.String(), strings.NewReader(encoded))
+	req.Header.Add("Authorization", "Bearer "+token)
+	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Add("Content-Length", fmt.Sprintf("%d", len(encoded)))
+	res, err := client.Do(req)
+
+	// status code is 403 when not allowed by authorization server
+	isAllowedAccess := err == nil && res.StatusCode == 200
+
+	defer res.Body.Close()
+
+	return isAllowedAccess, err
+}
+
+// Get user with token
+
+// User is the intermediate user object used when fetching
+// user info from the authentication service.
+type User struct {
+	ID       string `json:"id"`
+	Email    string `json:"email"`
+	Verified bool   `json:"verified_email"`
+	Hd       string `json:"hd"`
+}
+
+// GetUser retries the user info for the given token from the authentication service.
+func (w *WellKnownOpenIDConfiguration) GetUser(token string) (User, error) {
+	var user User
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: w.insecureCertificates},
+		},
+	}
+	req, err := http.NewRequest("GET", w.userURL.String(), nil)
+	if err != nil {
+		return user, err
+	}
+
+	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", token))
+	res, err := client.Do(req)
+	if err != nil {
+		return user, err
+	}
+
+	defer res.Body.Close()
+	err = json.NewDecoder(res.Body).Decode(&user)
+
+	return user, err
+}
+
 // ResolveWellKnownOpenIDConfiguration resolves the well known open ID configuration for a given realm.
-func ResolveWellKnownOpenIDConfiguration(logger logrus.FieldLogger, realmURI, username, password string) (*WellKnownOpenIDConfiguration, error) {
+func ResolveWellKnownOpenIDConfiguration(logger logrus.FieldLogger, realmURI, username, password string, prompt string, scope string, insecureCertificates bool) (*WellKnownOpenIDConfiguration, error) {
 	request, requestError := http.NewRequest("GET", fmt.Sprintf("%s/.well-known/openid-configuration", realmURI), nil)
 	if requestError != nil {
 		return nil, requestError
@@ -204,13 +353,19 @@ func ResolveWellKnownOpenIDConfiguration(logger logrus.FieldLogger, realmURI, us
 	}
 	cfg := &WellKnownOpenIDConfiguration{
 		logger: logger,
-		credentials: &TokenValidationEndpointCredentials{
-			Username: username,
-			Password: password,
+		insecureCertificates: insecureCertificates,
+		prompt: prompt,
+		scope: scope,
+		credentials: &OIDCClientCredentials{
+			ClientID:     username,
+			ClientSecret: password,
 		},
 	}
 	if jsonError := json.Unmarshal(responseBytes, cfg); jsonError != nil {
 		return nil, jsonError
 	}
+
+	cfg.Resolve()
+
 	return cfg, nil
 }

--- a/wellknownopenidconfiguration/implementation_test.go
+++ b/wellknownopenidconfiguration/implementation_test.go
@@ -1,0 +1,85 @@
+package wellknownopenidconfiguration
+
+import (
+	"fmt"
+	"github.com/Klarrio/traefik-forward-auth/util"
+	"net/http"
+	"net/url"
+	"reflect"
+	"testing"
+)
+
+func TestGetLoginURL(t *testing.T) {
+	r, _ := http.NewRequest("GET", "http://example.com", nil)
+	r.Header.Add("X-Forwarded-Proto", "http")
+	r.Header.Add("X-Forwarded-Host", "example.com")
+	r.Header.Add("X-Forwarded-Uri", "/hello")
+
+	oidcApi := NewWellKnownOpenIDConfiguration(
+		util.CreateLogger("debug", "text"),
+		&OIDCClientCredentials{
+			ClientID:     "idtest",
+			ClientSecret: "sectest",
+		},
+		"scopetest",
+		"consent select_account")
+
+	oidcApi.AuthorizationEndpoint = "https://test.com/auth"
+	oidcApi.TokenEndpoint = "https://test.com/token"
+	oidcApi.UserInfoEndpoint = "https://test.com/user"
+	oidcApi.Resolve()
+
+	// Check url
+	uri, err := url.Parse(oidcApi.GetLoginURL("nonce", "http://example.com/hello", "http://example.com/_oauth"))
+	if err != nil {
+		t.Error("Error parsing login url:", err)
+	}
+	if uri.Scheme != "https" {
+		t.Error("Expected login Scheme to be \"https\", got:", uri.Scheme)
+	}
+	if uri.Host != "test.com" {
+		t.Error("Expected login Host to be \"test.com\", got:", uri.Host)
+	}
+	if uri.Path != "/auth" {
+		t.Error("Expected login Path to be \"/auth\", got:", uri.Path)
+	}
+
+	// Check query string
+	qs := uri.Query()
+	expectedQs := url.Values{
+		"client_id":     []string{"idtest"},
+		"redirect_uri":  []string{"http://example.com/_oauth"},
+		"response_type": []string{"code"},
+		"scope":         []string{"scopetest"},
+		"prompt":        []string{"consent select_account"},
+		"state":         []string{"nonce:http://example.com/hello"},
+	}
+	if !reflect.DeepEqual(qs, expectedQs) {
+		t.Error("Incorrect login query string:")
+		qsDiff(expectedQs, qs)
+	}
+}
+
+// TODO
+// func TestExchangeCode(t *testing.T) {
+// }
+
+// TODO
+// func TestGetUser(t *testing.T) {
+// }
+
+func qsDiff(one, two url.Values) {
+	for k := range one {
+		if two.Get(k) == "" {
+			fmt.Printf("Key missing: %s\n", k)
+		}
+		if one.Get(k) != two.Get(k) {
+			fmt.Printf("Value different for %s: expected: '%s' got: '%s'\n", k, one.Get(k), two.Get(k))
+		}
+	}
+	for k := range two {
+		if one.Get(k) == "" {
+			fmt.Printf("Extra key: %s\n", k)
+		}
+	}
+}

--- a/wellknownopenidconfiguration/token.go
+++ b/wellknownopenidconfiguration/token.go
@@ -1,4 +1,4 @@
-package main
+package wellknownopenidconfiguration
 
 import (
 	"encoding/base64"
@@ -7,6 +7,16 @@ import (
 	"strings"
 	"time"
 )
+
+// Token is the intermediate authorization token object
+// used for token deserialization during the token exchange.
+type Token struct {
+	AccessToken  string `json:"access_token"`
+	TokenType    string `json:"token_type"`
+	RefreshToken string `json:"refresh_token"`
+	ExpiresIn    int    `json:"expires_in"`
+	IDToken      string `json:"id_token"`
+}
 
 // BearerToken is an intermediate object used for parsing bearer tokens
 // retrieved from the wire.
@@ -40,7 +50,7 @@ func (bt *BearerToken) ExpTime() time.Time {
 	return time.Unix(int64(bt.Exp), 0)
 }
 
-func bearerTokenFromWire(wireMessage string) (*BearerToken, error) {
+func BearerTokenFromWire(wireMessage string) (*BearerToken, error) {
 
 	// we receive a JWT token, the format is:
 	// header.payload.signature
@@ -50,7 +60,7 @@ func bearerTokenFromWire(wireMessage string) (*BearerToken, error) {
 	// token comes from Keycloak, we store it in memory, serve it to the app.
 	// It should be the app's responsibility to validate.
 
-	payloadBytes, err := payloadBytesFromJwt(wireMessage)
+	payloadBytes, err := PayloadBytesFromJwt(wireMessage)
 	if err != nil {
 		return nil, err
 	}
@@ -62,7 +72,7 @@ func bearerTokenFromWire(wireMessage string) (*BearerToken, error) {
 	return token, nil
 }
 
-func payloadBytesFromJwt(wireMessage string) ([]byte, error) {
+func PayloadBytesFromJwt(wireMessage string) ([]byte, error) {
 	// we receive a JWT token, the format is:
 	// header.payload.signature
 


### PR DESCRIPTION
- refactor: split off session-management to separate package and move all oidc calls to the wellknownopenidconfiguration
- only allow one thread per session to refresh the access token, to avoid having multiple requests of the same session refreshing the same access token (which can result in token refresh errors and unneeded pressure on the oidc server)